### PR TITLE
Simplify validating against specific object type(s)

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,9 +1,13 @@
 'use strict'
 
 const validJourney = require('friendly-public-transport-format/examples/valid-journey.json')
+const validStation = {type: 'station', id: '123', name: 'foo', location: {type: 'location', latitude: 1, longitude: 2}}
+const validStop = {type: 'stop', id: '321', name: 'foo', location: {type: 'location', latitude: 1, longitude: 2}, station: validStation}
 
 const createValidate = require('.')
 
 const validate = createValidate()
 
 validate(validJourney)
+validate(validStation, 'station')
+validate(validStop, ['station', 'stop'])

--- a/index.js
+++ b/index.js
@@ -38,8 +38,11 @@ const defaultValidators = {
 
 const createValidate = (validators = {}) => {
   const val = Object.assign({}, defaultValidators, validators)
-  const validate = (item, name = 'item') => {
-    anyOf(Object.keys(val), val, item, name)
+  const validate = (item, types = undefined, name = 'item') => {
+    if (!types) anyOf(Object.keys(val), val, item, name)
+    else if (typeof types === 'string') defaultValidators[types](val, item, name)
+    else if (Array.isArray(types)) anyOf(types, val, item, name)
+    else throw new TypeError('types has to be of type undefined, string or array')
   }
   return validate
 }

--- a/readme.md
+++ b/readme.md
@@ -50,18 +50,39 @@ validate({
     currency: 'EUR'
   }
 })
+
+validate({
+  type: 'station',
+  id: '123',
+  name: 'foo',
+  location: {
+    type: 'location',
+    latitude: 1,
+    longitude: 2
+  }
+}, ['station', 'stop'])
 ```
 
 
 ## API
 
 ```js
-validate(obj, [validators])
+createValidate([validators])
+```
+
+Returns the `validate` method below.
+
+You may provide an object `validators`, where each key is an *FPTF* type, and the corresponding function validates an *FPTF* object of this type.
+
+```js
+validate(obj, [types], [name])
 ```
 
 Recursively walks `obj`. Throws an [`AssertionError`](https://nodejs.org/api/errors.html#errors_class_assertionerror) if something is not valid [FPTF `1.0.1`](https://github.com/public-transport/friendly-public-transport-format/blob/1.0.1/spec/readme.md).
 
-You may provide an object `validators`, where each key is an *FPTF* type, and the corresponding function validates an *FPTF* object of this type.
+You may provide a string or an array `types` to validate against one or multiple specific FPTF object types.
+
+It is possible to specify a name for the root element by providing the `name` parameter.
 
 
 ## Contributing

--- a/test.js
+++ b/test.js
@@ -10,8 +10,6 @@ const validate = createValidate()
 
 test('passes with valid-journey.json from FPTF', (t) => {
   t.doesNotThrow(() => validate(validJourney))
-  t.doesNotThrow(() => validate(validSimpleJourney))
-  t.throws(() => validate(invalidJourney))
 
   t.end()
 })
@@ -24,6 +22,20 @@ test('passes with valid-simple-journey.json from FPTF', (t) => {
 
 test('fails with invalid-journey.json from FPTF', (t) => {
   t.throws(() => validate(invalidJourney))
+
+  t.end()
+})
+
+test('passes with valid-journey.json from FPTF when validating against journey type', (t) => {
+  t.doesNotThrow(() => validate(validJourney, 'journey'))
+  t.doesNotThrow(() => validate(validJourney, ['journey', 'schedule']))
+
+  t.end()
+})
+
+test('fails with valid-journey.json from FPTF when validating against non-journey type', (t) => {
+  t.throws(() => validate(validJourney, 'schedule'))
+  t.throws(() => validate(validJourney, ['stop', 'station']))
 
   t.end()
 })


### PR DESCRIPTION
This PR adds a new parameter to the `validate` method to specify *FPTF* object types to validate against. It should be pretty backwards-compatible, but as it inserts the new parameter between `item` and `name`, modules using the latter have to be adjusted.

Fixes #4 .